### PR TITLE
Remove the prov_dev_set_symmetric_key_info function in iotc.cpp

### DIFF
--- a/MXCHIP/mxchip_advanced/src/iotc/sdk_plat/iotc.cpp
+++ b/MXCHIP/mxchip_advanced/src/iotc/sdk_plat/iotc.cpp
@@ -15,11 +15,6 @@
 #include "azure_prov_client/prov_transport_mqtt_client.h"
 #include <AzureIotHub.h>
 #include "provisioning_client/adapters/hsm_client_key.h"
-int prov_dev_set_symmetric_key_info(const char* registration_name, const char* symmetric_key) {
-    hsm_client_set_registration_name_and_key(registration_name, symmetric_key);
-    return 0;
-}
-
 void IOTC_LOG(const __FlashStringHelper *format, ...) {
     if (getLogLevel() > IOTC_LOGGING_DISABLED) {
         va_list ap;

--- a/MXCHIP/mxchip_basic/src/iotc/sdk_plat/iotc.cpp
+++ b/MXCHIP/mxchip_basic/src/iotc/sdk_plat/iotc.cpp
@@ -15,11 +15,6 @@
 #include "azure_prov_client/prov_transport_mqtt_client.h"
 #include <AzureIotHub.h>
 #include "provisioning_client/adapters/hsm_client_key.h"
-int prov_dev_set_symmetric_key_info(const char* registration_name, const char* symmetric_key) {
-    hsm_client_set_registration_name_and_key(registration_name, symmetric_key);
-    return 0;
-}
-
 void IOTC_LOG(const __FlashStringHelper *format, ...) {
     if (getLogLevel() > IOTC_LOGGING_DISABLED) {
         va_list ap;


### PR DESCRIPTION
 The iot c sdk provide this api in the new release 1.2.12