### PR TITLE
Fix wrong case in import and add extra steps in readme

### DIFF
--- a/ESP8266/README.md
+++ b/ESP8266/README.md
@@ -18,9 +18,16 @@
 Compile it! and deploy to your device. (see below)
 
 - Download Arduino-CLI from [this link](https://github.com/arduino/arduino-cli#download-the-latest-stable-release)
+- Add additional url to board manager in .cli-config.yml (this is usually located in the same folder of CLI executable)
 
+```
+board_manager:
+  additional_urls:
+  - http://arduino.esp8266.com/stable/package_esp8266com_index.json
+```
 Setup the environment; (under the project folder)
 ```
+arduino-cli-0.3.3 core update-index
 arduino-cli-0.3.3 core install esp8266:esp8266
 arduino-cli-0.3.3 board attach esp8266:esp8266:nodemcu
 ```

--- a/ESP8266/src/iotc/common/base64.cpp
+++ b/ESP8266/src/iotc/common/base64.cpp
@@ -6,7 +6,7 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 */
 
 #ifdef ARDUINO
-#include "Base64.h"
+#include "base64.h"
 #include <avr/pgmspace.h>
 
 const char PROGMEM b64_alphabet[] = "ABCDEFGHIJKLMNOPQRSTUVWXYZ"

--- a/ESP8266/src/iotc/common/iotc_platform.h
+++ b/ESP8266/src/iotc/common/iotc_platform.h
@@ -50,7 +50,7 @@
 #define F(x) x
 
 #elif defined (ARDUINO)
-#include <arduino.h>
+#include <Arduino.h>
 #include <avr/pgmspace.h>
 #include "WiFiUdp.h"
 #include "base64.h"


### PR DESCRIPTION
Compilation fails in case-sensitive file systems because of wrong import.

Added required steps in the readme