### PR TITLE
Update sensory.cpp readAccelerometer

### DIFF
--- a/MXCHIP/mxchip_advanced/src/sensors.cpp
+++ b/MXCHIP/mxchip_advanced/src/sensors.cpp
@@ -132,9 +132,9 @@ void SensorController::readAccelerometer(int *axes) {
     LOG_VERBOSE("SensorController::readAccelerometer");
     bool hasFailed = false;
 
-    assert(magnetometer != NULL);
-    if (magnetometer == NULL) {
-        LOG_ERROR("Trying to do readMagnetometer while the sensor wasn't initialized.");
+    assert(accelGyro != NULL);
+    if (accelGyro == NULL) {
+        LOG_ERROR("Trying to do readAccelerometer while the sensor wasn't initialized.");
         hasFailed = true;
     }
 


### PR DESCRIPTION
Changed the readings for SensorController::readAccelerometer. I also noticed `if (accelGyro->getXAxes(axes) != 0) {` uses getXAxes, does this not include data for Y and Z?

It looks like the X axes is used to calculate Y and Z.

```cpp
/**
 * @brief  Read data from LSM6DSL Accelerometer
 * @param  pData the pointer where the accelerometer data are stored
 * @retval 0 in case of success, an error code otherwise
 */
int LSM6DSLSensor::getXAxes(int *pData)
{
  int16_t dataRaw[3];
  float sensitivity = 0;
  
  /* Read raw data from LSM6DSL output register. */
  if ( getXAxesRaw( dataRaw ) == 1 )
  {
    return 1;
  }
  
  /* Get LSM6DSL actual sensitivity. */
  if ( getXSensitivity( &sensitivity ) == 1 )
  {
    return 1;
  }
  
  /* Calculate the data. */
  pData[0] = ( int )( dataRaw[0] * sensitivity );
  pData[1] = ( int )( dataRaw[1] * sensitivity );
  pData[2] = ( int )( dataRaw[2] * sensitivity );
  
  return 0;
}
```