### PR TITLE
Remove explicitly set Content-Length HTTP Header

### DIFF
--- a/HttpOnly/Bash/dobash.sh
+++ b/HttpOnly/Bash/dobash.sh
@@ -33,7 +33,7 @@ getAuth
 # use the Auth and make a PUT request to Azure IoT DPS service
 OUT=`curl \
   -H "authorization: ${AUTH}&skn=registration" \
-  -H 'content-type: application/json; charset=utf-8' -H 'content-length: 25' \
+  -H 'content-type: application/json; charset=utf-8' \
   -s \
   --request PUT --data "{\"registrationId\":\"$DEVICE_ID\"}" "https://global.azure-devices-provisioning.net/$SCOPEID/registrations/$DEVICE_ID/register?api-version=2018-11-01"`
 


### PR DESCRIPTION
Content-Length header is automatically set by curl, so no need to have an error-prone hard-coded length.
Fixes issue #83.