### PR TITLE
Fix return value in jsobject_get_object_by_name

### DIFF
--- a/ESP8266/src/iotc/common/iotc_json.c
+++ b/ESP8266/src/iotc/common/iotc_json.c
@@ -71,7 +71,7 @@ int jsobject_get_object_by_name(jsobject_t *object, const char *name,
                                 jsobject_t *out) {
   int index = jsobject_get_index_by_name(object, name);
   if (index == -1) {
-    return 1;  // let consumer file the log
+    return -1;  // let consumer file the log
   }
 
   jsmntok_t token = object->tokens[index + 1];


### PR DESCRIPTION
Seems to be a typo. The calling code expects this function to return -1 when the object is not found.