### PR TITLE
Implement the HttpOnly sample in dotnet core 3

### DIFF
--- a/HttpOnly/dotnet/src/AuthHelper.cs
+++ b/HttpOnly/dotnet/src/AuthHelper.cs
@@ -1,0 +1,24 @@
+using System;
+using System.Security.Cryptography;
+using System.Text;
+
+namespace iotCentral.Http
+{
+    public static class AuthHelper {
+        public static string getAuth(string scope, string target, string deviceId, string deviceKey)
+        {
+            long utcTimeInMilliseconds = DateTime.UtcNow.Ticks / 10000;
+            long expires = ((utcTimeInMilliseconds + (7200 * 1000)) / 1000);
+            string sr = scope + "%2f" + target + "%2f" + deviceId;
+            string sigNoEncode = computeHash(deviceKey, sr + '\n' + expires.ToString());
+            string sigEncoded = Uri.EscapeDataString(sigNoEncode);
+            return "sr=" + sr + "&sig=" + sigEncoded + "&se=" + expires.ToString();
+        }
+        
+        private static string computeHash(string key, string Id)
+        {
+            HMACSHA256 hmac = new HMACSHA256(System.Convert.FromBase64String(key));
+            return System.Convert.ToBase64String(hmac.ComputeHash(Encoding.ASCII.GetBytes(Id)));
+        }
+    }
+}

--- a/HttpOnly/dotnet/src/AuthHelper.cs
+++ b/HttpOnly/dotnet/src/AuthHelper.cs
@@ -5,17 +5,17 @@ using System.Text;
 namespace iotCentral.Http
 {
     public static class AuthHelper {
-        public static string getAuth(string scope, string target, string deviceId, string deviceKey)
+        public static string GetAuthenticationValue(string scope, string target, string deviceId, string deviceKey)
         {
             long utcTimeInMilliseconds = DateTime.UtcNow.Ticks / 10000;
             long expires = ((utcTimeInMilliseconds + (7200 * 1000)) / 1000);
-            string sr = scope + "%2f" + target + "%2f" + deviceId;
-            string sigNoEncode = computeHash(deviceKey, sr + '\n' + expires.ToString());
+            string sr = $"{scope}%2f{target}%2f{deviceId}";
+            string sigNoEncode = ComputeHash(deviceKey, $"{sr}\n{expires.ToString()}");
             string sigEncoded = Uri.EscapeDataString(sigNoEncode);
-            return "sr=" + sr + "&sig=" + sigEncoded + "&se=" + expires.ToString();
+            return $"sr={sr}&sig={sigEncoded}&se={expires.ToString()}";
         }
         
-        private static string computeHash(string key, string Id)
+        private static string ComputeHash(string key, string Id)
         {
             HMACSHA256 hmac = new HMACSHA256(System.Convert.FromBase64String(key));
             return System.Convert.ToBase64String(hmac.ComputeHash(Encoding.ASCII.GetBytes(Id)));

--- a/HttpOnly/dotnet/src/IRequestHelper.cs
+++ b/HttpOnly/dotnet/src/IRequestHelper.cs
@@ -1,0 +1,11 @@
+using System.Threading.Tasks;
+
+namespace iotCentral.Http
+{
+    public interface IRequestHelper
+    {
+        Task<RegistrationOperationStatus> AddRegistrationAsync(string payload, string authScope, string deviceId, string deviceKey);
+        Task<RegistrationOperationStatus> GetRegistrationAsync(string authScope, string operationId, string deviceId, string deviceKey);
+        Task<bool> PostTelemetryAsync(string payload, string hostName, string deviceId, string deviceKey);
+    }
+}

--- a/HttpOnly/dotnet/src/IoTCentralDemo.cs
+++ b/HttpOnly/dotnet/src/IoTCentralDemo.cs
@@ -1,18 +1,22 @@
 using System;
 using System.Threading.Tasks;
+using Microsoft.Extensions.Configuration;
 
 namespace iotCentral.Http
 {
     public class IoTCentralDemo
     {
         private readonly IRequestHelper requestHelper;
-        string scopeId = "ENTER SCOPE ID HERE";
-        string deviceId = "ENTER DEVICE ID HERE";
-        string deviceKey = "ENTER DEVICE KEY HERE=";
+        string scopeId = "";
+        string deviceId = "";
+        string deviceKey = "";
 
-        public IoTCentralDemo(IRequestHelper requestHelper)
+        public IoTCentralDemo(IRequestHelper requestHelper, IConfiguration config)
         {
             this.requestHelper = requestHelper;
+            this.scopeId = config["scopeId"];
+            this.deviceId = config["deviceId"];
+            this.deviceKey = config["deviceKey"];
         }
 
         public async Task Run()
@@ -47,16 +51,20 @@ namespace iotCentral.Http
                 return;
             }
 
-            var successfullySentTelemetry = await requestHelper.PostTelemetryAsync("{\"temp\" : 15}", result.registrationState.assignedHub, deviceId, deviceKey);
-            
-            if (successfullySentTelemetry)
-            {
-                Console.WriteLine("Success!! Check the new temperature telemetry on Azure IoT Central Device window");
-            }
-            else
-            {
-                Console.WriteLine("Unable to send telemetry.");
-            }
+            bool successfullySentTelemetry = true;
+            do {
+                var random = (new Random().NextDouble()*3d) + 15d;
+                successfullySentTelemetry = await requestHelper.PostTelemetryAsync($"{{\"temp\" : {random}}}", result.registrationState.assignedHub, deviceId, deviceKey);
+                
+                if (successfullySentTelemetry)
+                {
+                    Console.WriteLine($"Success!! Sent to IoT Central {{\"temp\" : {random}}}");
+                }
+                else
+                {
+                    Console.WriteLine("Unable to send telemetry.");
+                }
+            } while (successfullySentTelemetry);
             
         }
     }

--- a/HttpOnly/dotnet/src/IoTCentralDemo.cs
+++ b/HttpOnly/dotnet/src/IoTCentralDemo.cs
@@ -34,16 +34,16 @@ namespace iotCentral.Http
                     
                     //todo check on "error"
 
-                    if (result.registrationState != null)
-                    {
-                        if (result.registrationState.assignedHub != null)
-                            break;
+                    if (result.registrationState != null && 
+                        result.registrationState.assignedHub != null)
+                    {    
+                        break;
                     }
                 }
             }
             if (!string.IsNullOrEmpty(result.registrationState.errorMessage))
             {
-                Console.WriteLine("ERROR: " + result.registrationState.errorMessage);
+                Console.WriteLine($"ERROR: {result.registrationState.errorMessage}");
                 return;
             }
 

--- a/HttpOnly/dotnet/src/IoTCentralDemo.cs
+++ b/HttpOnly/dotnet/src/IoTCentralDemo.cs
@@ -24,8 +24,6 @@ namespace iotCentral.Http
             // get operationId from Azure IoT DPS
             var result = await requestHelper.AddRegistrationAsync("{\"registrationId\":\"" + deviceId + "\"}", scopeId, deviceId, deviceKey);
             
-            //todo check on "error"
-
             if (result.status == DeviceEnrollmentStatus.assigning) {
                 // Using the operationId and the rest of the credentials, get hostname for the Azure IoT hub
                 // The reason for the loop is that the async op. we had triggered with the operationId request
@@ -36,8 +34,6 @@ namespace iotCentral.Http
                     System.Threading.Thread.Sleep(2500);
                     result = await requestHelper.GetRegistrationAsync(scopeId, result.operationId, deviceId, deviceKey);
                     
-                    //todo check on "error"
-
                     if (result.registrationState != null && 
                         result.registrationState.assignedHub != null)
                     {    

--- a/HttpOnly/dotnet/src/IoTCentralDemo.cs
+++ b/HttpOnly/dotnet/src/IoTCentralDemo.cs
@@ -1,0 +1,63 @@
+using System;
+using System.Threading.Tasks;
+
+namespace iotCentral.Http
+{
+    public class IoTCentralDemo
+    {
+        private readonly IRequestHelper requestHelper;
+        string scopeId = "ENTER SCOPE ID HERE";
+        string deviceId = "ENTER DEVICE ID HERE";
+        string deviceKey = "ENTER DEVICE KEY HERE=";
+
+        public IoTCentralDemo(IRequestHelper requestHelper)
+        {
+            this.requestHelper = requestHelper;
+        }
+
+        public async Task Run()
+        {
+            // get operationId from Azure IoT DPS
+            var result = await requestHelper.AddRegistrationAsync("{\"registrationId\":\"" + deviceId + "\"}", scopeId, deviceId, deviceKey);
+            
+            //todo check on "error"
+
+            if (result.status == DeviceEnrollmentStatus.assigning) {
+                // Using the operationId and the rest of the credentials, get hostname for the Azure IoT hub
+                // The reason for the loop is that the async op. we had triggered with the operationId request
+                // may take more than 2secs.
+                // So, wait for 2 secs+ each time and then try again
+                for (int i = 0; i < 10; i++) // try 5 times
+                {
+                    System.Threading.Thread.Sleep(2500);
+                    result = await requestHelper.GetRegistrationAsync(scopeId, result.operationId, deviceId, deviceKey);
+                    
+                    //todo check on "error"
+
+                    if (result.registrationState != null)
+                    {
+                        if (result.registrationState.assignedHub != null)
+                            break;
+                    }
+                }
+            }
+            if (!string.IsNullOrEmpty(result.registrationState.errorMessage))
+            {
+                Console.WriteLine("ERROR: " + result.registrationState.errorMessage);
+                return;
+            }
+
+            var successfullySentTelemetry = await requestHelper.PostTelemetryAsync("{\"temp\" : 15}", result.registrationState.assignedHub, deviceId, deviceKey);
+            
+            if (successfullySentTelemetry)
+            {
+                Console.WriteLine("Success!! Check the new temperature telemetry on Azure IoT Central Device window");
+            }
+            else
+            {
+                Console.WriteLine("Unable to send telemetry.");
+            }
+            
+        }
+    }
+}

--- a/HttpOnly/dotnet/src/Models/RegistrationOperationStatus.cs
+++ b/HttpOnly/dotnet/src/Models/RegistrationOperationStatus.cs
@@ -1,6 +1,7 @@
-public struct RegistrationOperationStatus {
+public struct RegistrationOperationStatus
+{
     public string operationId { get; set; }
-    public DeviceRegistrationResult registrationState { get; set; } 
+    public DeviceRegistrationResult registrationState { get; set; }
     public DeviceEnrollmentStatus? status { get; set; }
 }
 
@@ -21,13 +22,15 @@ public class DeviceRegistrationResult
     //unimplemented: symmetricKey, tpm, x509
 }
 
-public enum DeviceEnrollmentSubStatus {
+public enum DeviceEnrollmentSubStatus
+{
     deviceDataMigrated,
-deviceDataReset,
-initialAssignment
+    deviceDataReset,
+    initialAssignment
 }
 
-public enum DeviceEnrollmentStatus {
+public enum DeviceEnrollmentStatus
+{
     assigned,
     assigning,
     disabled,

--- a/HttpOnly/dotnet/src/Models/RegistrationOperationStatus.cs
+++ b/HttpOnly/dotnet/src/Models/RegistrationOperationStatus.cs
@@ -1,0 +1,36 @@
+public struct RegistrationOperationStatus {
+    public string operationId { get; set; }
+    public DeviceRegistrationResult registrationState { get; set; } 
+    public DeviceEnrollmentStatus? status { get; set; }
+}
+
+public class DeviceRegistrationResult
+{
+    public string assignedHub { get; set; }
+    public string createdDateTimeUtc { get; set; }
+    public string deviceId { get; set; }
+    public int errorCode { get; set; }
+    public string errorMessage { get; set; }
+    public string etag { get; set; }
+    public string lastUpdatedDateTimeUtc { get; set; }
+    public object payload { get; set; }
+    public string registrationId { get; set; }
+    public DeviceEnrollmentStatus status { get; set; }
+    public DeviceEnrollmentSubStatus subStatus { get; set; }
+
+    //unimplemented: symmetricKey, tpm, x509
+}
+
+public enum DeviceEnrollmentSubStatus {
+    deviceDataMigrated,
+deviceDataReset,
+initialAssignment
+}
+
+public enum DeviceEnrollmentStatus {
+    assigned,
+    assigning,
+    disabled,
+    failed,
+    unassigned
+}

--- a/HttpOnly/dotnet/src/Program.cs
+++ b/HttpOnly/dotnet/src/Program.cs
@@ -1,0 +1,31 @@
+﻿using System;
+using System.Diagnostics;
+using System.Net.Http;
+using System.Threading.Tasks;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace iotCentral.Http
+{
+    class Program
+    {
+        static async Task Main(string[] args)
+        {
+            try {
+                var serviceProvider = new ServiceCollection()
+                                    .AddHttpClient()
+                                    .AddTransient<IRequestHelper>((serv)=>new RequestHelper(serv.GetService<IHttpClientFactory>()))
+                                    .AddSingleton<IoTCentralDemo>()
+                                    .BuildServiceProvider();
+                
+                IoTCentralDemo demo = serviceProvider.GetService<IoTCentralDemo>();
+                await demo.Run();
+            }
+            catch (Exception ex)
+            {
+                Console.WriteLine(ex.ToString());
+                Debugger.Break();
+                
+            }
+        }
+    }
+}

--- a/HttpOnly/dotnet/src/Program.cs
+++ b/HttpOnly/dotnet/src/Program.cs
@@ -3,6 +3,8 @@ using System.Diagnostics;
 using System.Net.Http;
 using System.Threading.Tasks;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Configuration;
+using System.IO;
 
 namespace iotCentral.Http
 {
@@ -11,11 +13,17 @@ namespace iotCentral.Http
         static async Task Main(string[] args)
         {
             try {
+                var builder = new ConfigurationBuilder()
+                    .SetBasePath(Directory.GetCurrentDirectory())
+                    .AddJsonFile("appsettings.json", optional: true, reloadOnChange: true);
+
                 var serviceProvider = new ServiceCollection()
                                     .AddHttpClient()
                                     .AddTransient<IRequestHelper>((serv)=>new RequestHelper(serv.GetService<IHttpClientFactory>()))
+                                    .AddSingleton<IConfiguration>(builder.Build())
                                     .AddSingleton<IoTCentralDemo>()
                                     .BuildServiceProvider();
+                                    
                 
                 IoTCentralDemo demo = serviceProvider.GetService<IoTCentralDemo>();
                 await demo.Run();

--- a/HttpOnly/dotnet/src/README.md
+++ b/HttpOnly/dotnet/src/README.md
@@ -1,0 +1,21 @@
+### Connecting to Azure IoT Central via HTTP (C#)
+
+To Run;
+```
+dotnet run 
+```
+
+Don't forget filling the required variables under `IoTCentralDemo.cs`
+```
+string scopeId = "ENTER SCOPE ID HERE";
+string deviceId = "ENTER DEVICE ID HERE";
+string deviceKey = "ENTER DEVICE KEY HERE=";
+```
+
+Open [apps.azureiotcentral.com](apps.azureiotcentral.com) `>` Device Explorer (explorer)
+`>` Select one of the templates (i.e. MXCHIP) `>` Click to `+` button on the tab `>`
+Select `Real device`
+
+You should see a `Connect` link on top-right of the device page. Once you click
+to that button, you will find all the `deviceId`, `deviceKey` (Primary_key) and
+`scopeId` there.

--- a/HttpOnly/dotnet/src/README.md
+++ b/HttpOnly/dotnet/src/README.md
@@ -1,4 +1,4 @@
-### Connecting to Azure IoT Central via HTTP (C#)
+# Connecting to Azure IoT Central via HTTP (C#)
 
 To Run;
 ```

--- a/HttpOnly/dotnet/src/README.md
+++ b/HttpOnly/dotnet/src/README.md
@@ -5,11 +5,13 @@ To Run;
 dotnet run 
 ```
 
-Don't forget filling the required variables under `IoTCentralDemo.cs`
+Don't forget filling the required variables in `appsettings.json`
 ```
-string scopeId = "ENTER SCOPE ID HERE";
-string deviceId = "ENTER DEVICE ID HERE";
-string deviceKey = "ENTER DEVICE KEY HERE=";
+{
+    "scopeId": "",
+    "deviceId": "",
+    "deviceKey": ""
+}
 ```
 
 Open [apps.azureiotcentral.com](apps.azureiotcentral.com) `>` Device Explorer (explorer)

--- a/HttpOnly/dotnet/src/RequestHelper.cs
+++ b/HttpOnly/dotnet/src/RequestHelper.cs
@@ -26,7 +26,7 @@ namespace iotCentral.Http
 
             string authTarget = "&skn=registration";
             string reason = "registrations";
-            httpClient.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("SharedAccessSignature", AuthHelper.getAuth(authScope, reason, deviceId, deviceKey) + authTarget);
+            httpClient.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("SharedAccessSignature", AuthHelper.GetAuthenticationValue(authScope, reason, deviceId, deviceKey) + authTarget);
 
             var response = await httpClient.PutAsync(address, requestBody);
 
@@ -41,7 +41,7 @@ namespace iotCentral.Http
             var httpClient = factory.CreateClient();
             string authTarget = "&skn=registration";
             string reason = "registrations";
-            httpClient.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("SharedAccessSignature", AuthHelper.getAuth(authScope, reason, deviceId, deviceKey) + authTarget);
+            httpClient.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("SharedAccessSignature", AuthHelper.GetAuthenticationValue(authScope, reason, deviceId, deviceKey) + authTarget);
             var response = await httpClient.GetAsync(address);
             
             return await JsonSerializer.DeserializeAsync<RegistrationOperationStatus>(
@@ -56,8 +56,8 @@ namespace iotCentral.Http
             requestBody.Headers.ContentType = new MediaTypeHeaderValue("application/json");
 
             string reason = "devices";
-            //httpClient.DefaultRequestHeaders.Add("iothub-to", $"/devices/{deviceId}/messages/events");
-            httpClient.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("SharedAccessSignature", AuthHelper.getAuth(hostName, reason, deviceId, deviceKey));
+            httpClient.DefaultRequestHeaders.Add("iothub-to", $"/devices/{deviceId}/messages/events");
+            httpClient.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("SharedAccessSignature", AuthHelper.GetAuthenticationValue(hostName, reason, deviceId, deviceKey));
             var response = await httpClient.PostAsync(address, requestBody);
 
             return response.IsSuccessStatusCode;

--- a/HttpOnly/dotnet/src/RequestHelper.cs
+++ b/HttpOnly/dotnet/src/RequestHelper.cs
@@ -1,0 +1,66 @@
+using System.Net.Http;
+using System.Net.Http.Headers;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using System.Threading.Tasks;
+
+namespace iotCentral.Http
+{
+    public class RequestHelper : IRequestHelper {
+        private readonly IHttpClientFactory factory;
+        private JsonSerializerOptions options;
+
+        public RequestHelper(IHttpClientFactory factory)
+        {
+            this.factory = factory;
+            this.options = new JsonSerializerOptions();
+            this.options.Converters.Add(new JsonStringEnumConverter(JsonNamingPolicy.CamelCase));
+        }
+        public async Task<RegistrationOperationStatus> AddRegistrationAsync(string payload, string authScope, string deviceId, string deviceKey)
+        {
+            string address = $"https://global.azure-devices-provisioning.net/{authScope}/registrations/{deviceId}/register?api-version=2018-11-01";
+            
+            var httpClient = factory.CreateClient();
+            var requestBody = new StringContent(payload);
+            requestBody.Headers.ContentType = new MediaTypeHeaderValue("application/json");
+
+            string authTarget = "&skn=registration";
+            string reason = "registrations";
+            httpClient.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("SharedAccessSignature", AuthHelper.getAuth(authScope, reason, deviceId, deviceKey) + authTarget);
+
+            var response = await httpClient.PutAsync(address, requestBody);
+
+            return await JsonSerializer.DeserializeAsync<RegistrationOperationStatus>(
+                await response.Content.ReadAsStreamAsync(), this.options);
+        }
+
+        public async Task<RegistrationOperationStatus> GetRegistrationAsync(string authScope, string operationId, string deviceId, string deviceKey)
+        {
+            string address = $"https://global.azure-devices-provisioning.net/{authScope}/registrations/{deviceId}/operations/{operationId}?api-version=2018-11-01";
+
+            var httpClient = factory.CreateClient();
+            string authTarget = "&skn=registration";
+            string reason = "registrations";
+            httpClient.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("SharedAccessSignature", AuthHelper.getAuth(authScope, reason, deviceId, deviceKey) + authTarget);
+            var response = await httpClient.GetAsync(address);
+            
+            return await JsonSerializer.DeserializeAsync<RegistrationOperationStatus>(
+                await response.Content.ReadAsStreamAsync(), this.options);
+        }
+
+        public async Task<bool> PostTelemetryAsync(string payload, string hostName, string deviceId, string deviceKey) 
+        {
+            string address = $"https://{hostName}/devices/{deviceId}/messages/events/?api-version=2016-11-14";
+            var httpClient = factory.CreateClient();
+            var requestBody = new StringContent(payload);
+            requestBody.Headers.ContentType = new MediaTypeHeaderValue("application/json");
+
+            string reason = "devices";
+            //httpClient.DefaultRequestHeaders.Add("iothub-to", $"/devices/{deviceId}/messages/events");
+            httpClient.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("SharedAccessSignature", AuthHelper.getAuth(hostName, reason, deviceId, deviceKey));
+            var response = await httpClient.PostAsync(address, requestBody);
+
+            return response.IsSuccessStatusCode;
+        }
+    }
+}

--- a/HttpOnly/dotnet/src/RequestHelper.cs
+++ b/HttpOnly/dotnet/src/RequestHelper.cs
@@ -19,48 +19,54 @@ namespace iotCentral.Http
         public async Task<RegistrationOperationStatus> AddRegistrationAsync(string payload, string authScope, string deviceId, string deviceKey)
         {
             string address = $"https://global.azure-devices-provisioning.net/{authScope}/registrations/{deviceId}/register?api-version=2018-11-01";
-            
-            var httpClient = factory.CreateClient();
-            var requestBody = new StringContent(payload);
-            requestBody.Headers.ContentType = new MediaTypeHeaderValue("application/json");
 
-            string authTarget = "&skn=registration";
-            string reason = "registrations";
-            httpClient.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("SharedAccessSignature", AuthHelper.GetAuthenticationValue(authScope, reason, deviceId, deviceKey) + authTarget);
+            var httpClient = factory.CreateClient();
+            httpClient.DefaultRequestHeaders.Authorization = GetAuthenticationHeaderValue(authScope, deviceId, deviceKey, "&skn=registration", "registrations");
+            var requestBody = GetJsonPayload(payload);
 
             var response = await httpClient.PutAsync(address, requestBody);
 
             return await JsonSerializer.DeserializeAsync<RegistrationOperationStatus>(
                 await response.Content.ReadAsStreamAsync(), this.options);
         }
-
         public async Task<RegistrationOperationStatus> GetRegistrationAsync(string authScope, string operationId, string deviceId, string deviceKey)
         {
             string address = $"https://global.azure-devices-provisioning.net/{authScope}/registrations/{deviceId}/operations/{operationId}?api-version=2018-11-01";
 
-            var httpClient = factory.CreateClient();
-            string authTarget = "&skn=registration";
-            string reason = "registrations";
-            httpClient.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("SharedAccessSignature", AuthHelper.GetAuthenticationValue(authScope, reason, deviceId, deviceKey) + authTarget);
+            var httpClient = factory.CreateClient();            
+            httpClient.DefaultRequestHeaders.Authorization = GetAuthenticationHeaderValue(authScope, deviceId, deviceKey, "&skn=registration", "registrations");
+            
             var response = await httpClient.GetAsync(address);
             
             return await JsonSerializer.DeserializeAsync<RegistrationOperationStatus>(
                 await response.Content.ReadAsStreamAsync(), this.options);
         }
 
-        public async Task<bool> PostTelemetryAsync(string payload, string hostName, string deviceId, string deviceKey) 
+        public async Task<bool> PostTelemetryAsync(string payload, string hostName, string deviceId, string deviceKey)
         {
             string address = $"https://{hostName}/devices/{deviceId}/messages/events/?api-version=2016-11-14";
             var httpClient = factory.CreateClient();
-            var requestBody = new StringContent(payload);
-            requestBody.Headers.ContentType = new MediaTypeHeaderValue("application/json");
-
-            string reason = "devices";
             httpClient.DefaultRequestHeaders.Add("iothub-to", $"/devices/{deviceId}/messages/events");
-            httpClient.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("SharedAccessSignature", AuthHelper.GetAuthenticationValue(hostName, reason, deviceId, deviceKey));
+            httpClient.DefaultRequestHeaders.Authorization = GetAuthenticationHeaderValue(hostName, deviceId, deviceKey, string.Empty, "devices");
+
+            StringContent requestBody = GetJsonPayload(payload);
+
             var response = await httpClient.PostAsync(address, requestBody);
 
             return response.IsSuccessStatusCode;
         }
+
+        private static StringContent GetJsonPayload(string payload)
+        {
+            var requestBody = new StringContent(payload);
+            requestBody.Headers.ContentType = new MediaTypeHeaderValue("application/json");
+            return requestBody;
+        }
+        
+        private static AuthenticationHeaderValue GetAuthenticationHeaderValue(string authScope, string deviceId, string deviceKey, string authTarget, string reason)
+        {
+            return new AuthenticationHeaderValue("SharedAccessSignature", AuthHelper.GetAuthenticationValue(authScope, reason, deviceId, deviceKey) + authTarget);
+        }
+
     }
 }

--- a/HttpOnly/dotnet/src/appsettings.json
+++ b/HttpOnly/dotnet/src/appsettings.json
@@ -1,0 +1,5 @@
+{
+    "scopeId": "",
+    "deviceId": "",
+    "deviceKey": ""
+}

--- a/HttpOnly/dotnet/src/iotCentralHttp.csproj
+++ b/HttpOnly/dotnet/src/iotCentralHttp.csproj
@@ -1,0 +1,12 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>netcoreapp3.0</TargetFramework>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.Http" Version="3.0.1" />
+  </ItemGroup>
+
+</Project>

--- a/HttpOnly/dotnet/src/iotCentralHttp.csproj
+++ b/HttpOnly/dotnet/src/iotCentralHttp.csproj
@@ -6,6 +6,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="3.0.1" />
     <PackageReference Include="Microsoft.Extensions.Http" Version="3.0.1" />
   </ItemGroup>
 


### PR DESCRIPTION
The existing CSharp demo is improved by this pull request to move into dotnet core 3.0.

This updates the structure to abstract requests (RequestHelper.cs) from workflow (IoTCentralDemo.cs), uses modern C# approaches for code legibility and corrects bugs with the original implementation. 

The execution also puts a looping random value as telemetry, rather than static 15. 